### PR TITLE
DEP: python>=3.9; rasterio>=1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,17 @@ source:
   sha256: bbbda47fd7eb04c0986df553f11aa0bdbc9846e75601b8ebd704fc8573bfb835
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.9
     - pip
   run:
-    - python >=3.8
-    - rasterio >=1.1.1
+    - python >=3.9
+    - rasterio >=1.2
     - scipy
     - xarray >=0.17
     - pyproj >=2.2


### PR DESCRIPTION
Xref https://github.com/corteva/rioxarray/blame/0.14.0/setup.cfg. Fixes issue when running `rioxarray=0.14.0` with Python 3.8:

```python-traceback
    import rioxarray
../../../micromamba-root/envs/project/lib/python3.8/site-packages/rioxarray/__init__.py:5: in <module>
    import rioxarray.raster_array  # noqa
../../../micromamba-root/envs/project/lib/python3.8/site-packages/rioxarray/raster_array.py:37: in <module>
    from rioxarray.raster_writer import (
../../../micromamba-root/envs/project/lib/python3.8/site-packages/rioxarray/raster_writer.py:18: in <module>
    from rioxarray._io import _get_unsigned_dtype
../../../micromamba-root/envs/project/lib/python3.8/site-packages/rioxarray/_io.py:38: in <module>
    from rioxarray.rioxarray import _generate_spatial_coords
../../../micromamba-root/envs/project/lib/python3.8/site-packages/rioxarray/rioxarray.py:53: in <module>
    def _resolution(affine: Affine) -> tuple[float, float]:
E   TypeError: 'type' object is not subscriptable
```
Patches #69

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
