### PR TITLE
Sync numpy pinning with pyproject.toml.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 8bfc7e979edc7e30b4671d638a9be0e5a7d673dab2ea88e2445d3c7745599c02
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - xarray >=2024.7.0
     - pyproj >=3.3
     - packaging
-    - numpy >=1.23
+    - numpy >=2
 test:
   requires:
     - python {{ python_min }}


### PR DESCRIPTION
Since rioxarray 0.20.0 pins numpy to `>=2.0` in the pyproject.toml, this should also be considered in the conda-forge builds. Otherwise, conda will also install rioxarray 0.20.0 along with packages that require numpy<2. This is what just happened to me in https://github.com/conda-forge/staged-recipes/pull/31477. There, `pip check` fails with `rioxarray 0.20.0 has requirement numpy>=2, but you have numpy 1.26.4`.

This PR synchronizes the pinning with the pyproject.toml again.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
